### PR TITLE
cleanup ffetch.js

### DIFF
--- a/src/ffetch.js
+++ b/src/ffetch.js
@@ -10,11 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
+/* eslint-disable no-restricted-syntax,  no-await-in-loop */
+
 async function* request(url, context) {
-  const { chunks, sheet, fetch } = context;
-  for (let offset = 0, total = Infinity; offset < total; offset += chunks) {
-    const params = new URLSearchParams(`offset=${offset}&limit=${chunks}`);
-    if (sheet) params.append(`sheet`, sheet);
+  const { chunkSize, sheetName, fetch } = context;
+  for (let offset = 0, total = Infinity; offset < total; offset += chunkSize) {
+    const params = new URLSearchParams(`offset=${offset}&limit=${chunkSize}`);
+    if (sheetName) params.append('sheet', sheetName);
     const resp = await fetch(`${url}?${params.toString()}`);
     if (resp.ok) {
       const json = await resp.json();
@@ -38,20 +40,20 @@ function withHtmlParser(upstream, context, parseHtml) {
   return upstream;
 }
 
-function chunks(upstream, context, chunks) {
-  context.chunks = chunks;
+function chunks(upstream, context, chunkSize) {
+  context.chunkSize = chunkSize;
   return upstream;
 }
 
-function sheet(upstream, context, sheet) {
-  context.sheet = sheet;
+function sheet(upstream, context, sheetName) {
+  context.sheetName = sheetName;
   return upstream;
 }
 
-async function* skip(upstream, context, skip) {
+async function* skip(upstream, context, from) {
   let skipped = 0;
   for await (const entry of upstream) {
-    if (skipped < skip) {
+    if (skipped < from) {
       skipped += 1;
     } else {
       yield entry;
@@ -59,12 +61,12 @@ async function* skip(upstream, context, skip) {
   }
 }
 
-async function* limit(upstream, context, limit) {
+async function* limit(upstream, context, aLimit) {
   let yielded = 0;
   for await (const entry of upstream) {
     yield entry;
     yielded += 1;
-    if (yielded === limit) {
+    if (yielded === aLimit) {
       return;
     }
   }
@@ -158,18 +160,18 @@ function assignOperations(generator, context) {
 }
 
 export default function ffetch(url) {
-  let chunks = 255;
+  let chunkSize = 255;
   const fetch = (...rest) => window.fetch.apply(null, rest);
   const parseHtml = (html) => new window.DOMParser().parseFromString(html, 'text/html');
 
   try {
     if ('connection' in window.navigator && window.navigator.connection.saveData === true) {
       // request smaller chunks in save data mode
-      chunks = 64;
+      chunkSize = 64;
     }
   } catch (e) { /* ignore */ }
 
-  const context = { chunks, fetch, parseHtml };
+  const context = { chunkSize, fetch, parseHtml };
   const generator = request(url, context);
 
   return assignOperations(generator, context);


### PR DESCRIPTION
Eslint had a ton of complaints, so I tried to solve them. 

Note: I did not test all features. 

```

/Users/wingeier/workspace/franklin/24life/scripts/ffetch.js
   14:11  error  'chunks' is already declared in the upper scope on line 41 column 10                                                                                                       no-shadow
   14:19  error  'sheet' is already declared in the upper scope on line 46 column 10                                                                                                        no-shadow
   17:30  error  Strings must use singlequote                                                                                                                                               quotes
   18:18  error  Unexpected `await` inside a loop                                                                                                                                           no-await-in-loop
   20:20  error  Unexpected `await` inside a loop                                                                                                                                           no-await-in-loop
   22:7   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
   41:36  error  'chunks' is already declared in the upper scope on line 41 column 10                                                                                                       no-shadow
   46:35  error  'sheet' is already declared in the upper scope on line 46 column 10                                                                                                        no-shadow
   51:41  error  'skip' is already declared in the upper scope on line 51 column 17                                                                                                         no-shadow
   53:3   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
   62:42  error  'limit' is already declared in the upper scope on line 62 column 17                                                                                                        no-shadow
   64:3   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
   75:3   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
   78:7   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
   79:17  error  Unexpected `await` inside a loop                                                                                                                                           no-await-in-loop
   85:3   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
   86:13  error  Unexpected `await` inside a loop                                                                                                                                           no-await-in-loop
   92:3   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
  117:3   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
  125:3   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
  161:7   error  'chunks' is already declared in the upper scope on line 41 column 10                                                                                                       no-shadow

✖ 23 problems (21 errors, 2 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

```